### PR TITLE
chore: upgrade to Node.js 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Upgrade npm for trusted publishing


### PR DESCRIPTION
## Summary

fixes #132

- Upgrade Node.js version from 20 to 22 in GitHub Actions workflow