### PR TITLE
chore: pin actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_ACCESS_TOKEN }}
@@ -23,7 +23,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: 22.22.1
           registry-url: 'https://registry.npmjs.org/'


### PR DESCRIPTION
# Summary

- Pin `actions/checkout` from `@v6` to commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd`
- Pin `actions/setup-node` from `@v6` to commit SHA `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`