### PR TITLE
feat: add isPartOf to PublicServiceOutput

### DIFF
--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -364,6 +364,7 @@ export interface PublicServiceOutput {
   description: Partial<TextLanguage>;
   type: Partial<Concept>[];
   language: PublicServiceLanguage[];
+  isPartOf: string[];
 }
 
 export interface PublicServiceCriterionRequirement {


### PR DESCRIPTION
# Summary

- Legg til isPartOf (string[]) på PublicServiceOutput for dct:isPartOf på mulig tjenesteresultat

Del av #1929.