### PR TITLE
feat: support multiple dataset dctType

### DIFF
--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -680,7 +680,7 @@ export interface Dataset {
   language?: Partial<PrefLabelType>[];
   landingPage: string[];
   qualifiedAttributions: QualifiedAttribution[];
-  dctType?: (DatasetType | string)[];
+  dctType?: ReferenceDataCode[];
   specializedType?: SpecializedDatasetType;
   datasetsInSeries?: string[];
   inSeries?: InSeries;

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -621,12 +621,6 @@ interface AccrualPeriodicity {
   prefLabel: Partial<TextLanguage>;
 }
 
-export interface DatasetType {
-  uri: string;
-  code: string;
-  prefLabel: Partial<TextLanguage>;
-}
-
 interface LegalBasis {
   uri: string;
   prefLabel: Partial<TextLanguage>;

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -680,7 +680,7 @@ export interface Dataset {
   language?: Partial<PrefLabelType>[];
   landingPage: string[];
   qualifiedAttributions: QualifiedAttribution[];
-  dctType?: DatasetType | string;
+  dctType?: (DatasetType | string)[];
   specializedType?: SpecializedDatasetType;
   datasetsInSeries?: string[];
   inSeries?: InSeries;


### PR DESCRIPTION
# Summary

- Change `Dataset.dctType` from `DatasetType | string` to `(DatasetType | string)[]` to support 0..n dataset types