### PR TITLE
feat: allow dataset dctType as list or single

### DIFF
--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -674,7 +674,7 @@ export interface Dataset {
   language?: Partial<PrefLabelType>[];
   landingPage: string[];
   qualifiedAttributions: QualifiedAttribution[];
-  dctType?: ReferenceDataCode[];
+  dctType?: ReferenceDataCode[] | ReferenceDataCode;
   specializedType?: SpecializedDatasetType;
   datasetsInSeries?: string[];
   inSeries?: InSeries;


### PR DESCRIPTION
# Summary

- `Dataset.dctType` → `ReferenceDataCode[] | ReferenceDataCode`